### PR TITLE
Maintain release workflow

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -10,6 +10,8 @@ jobs:
   build-n-publish:
       name: Build and publish to PyPI
       runs-on: ubuntu-latest
+      permissions:
+        contents: write
 
       steps:
         - name: Checkout source
@@ -38,6 +40,7 @@ jobs:
         - name: Publish distribution to PyPI
           uses: pypa/gh-action-pypi-publish@release/v1
           with:
+            skip-existing: true
             password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
             # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
 


### PR DESCRIPTION
Hi Thomas,

This PR updates permission for release workflow and allow to skip if existing same version on pypi.

Thank you,
Ngoan